### PR TITLE
fix: address security vulnerabilities

### DIFF
--- a/comparison.php
+++ b/comparison.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once "resources/php/includes/security_headers.php";
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -18,8 +19,9 @@ session_start();
 <?php require "resources/php/includes/header.php" ?>
 <?php
 if(isset($_GET["player_1"]) || isset($_GET["player_2"])){
-    $player_1 = $_GET["player_1"];
-    $player_2 = $_GET["player_2"];
+    // Sanitize user input before embedding into HTML/JS context
+    $player_1 = htmlspecialchars($_GET["player_1"] ?? '', ENT_QUOTES, 'UTF-8');
+    $player_2 = htmlspecialchars($_GET["player_2"] ?? '', ENT_QUOTES, 'UTF-8');
     echo "<script>let from_url = true; let player_1_from_url = ".json_encode($player_1).";let player_2_from_url = ".json_encode($player_2)."</script>";
 }else{
     echo "<script>let from_url = false;</script>";

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once "resources/php/includes/security_headers.php";
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/resources/php/includes/db_connect.php
+++ b/resources/php/includes/db_connect.php
@@ -20,7 +20,9 @@ try {
     if (str_contains($e->getMessage(), 'could not find driver')) {
         echo "{\"error\":\"Could not find php ".$config['db_driver']." driver\"}";
     } else {
-        echo "{\"error\":\"".json_encode($e->getMessage(), JSON_PRETTY_PRINT)."\"}";
+        // Log the detailed error server-side only; never expose DB internals to the client
+        error_log('Database connection error: ' . $e->getMessage());
+        echo "{\"error\":\"A database error occurred. Please contact the administrator.\"}";
     }
     exit;
 }

--- a/resources/php/includes/secure.php
+++ b/resources/php/includes/secure.php
@@ -1,38 +1,47 @@
 <?php
-
 /**
  * Want to debug, test the scripts and avoid "Access denied" ?
  * Just put $debug = true; instead of false !
  */
-
 $debug = false;
 //$debug = true;
-
 session_start();
 
+/**
+ * Send recommended security headers for every response.
+ * Call this function before any output is sent.
+ */
+function sendSecurityHeaders()
+{
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: DENY');
+    header('Referrer-Policy: strict-origin-when-cross-origin');
+    // Allow only same-origin scripts; adjust if you use a CDN
+    header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:;");
+}
+
+/**
+ * Validate that the incoming POST request carries a valid CSRF token.
+ * HTTP_REFERER is intentionally NOT used because it can be spoofed by the client.
+ *
+ * @return bool
+ */
 function isValidRequest()
 {
-    if (!isset($_SERVER['HTTP_REFERER'])) {
-        return false;
-    }
-
-    $referer = parse_url($_SERVER['HTTP_REFERER']);
-    $serverName = $_SERVER['SERVER_NAME'];
-
-    if ($referer['host'] !== $serverName) {
-        return false;
-    }
-
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
         return false;
     }
-
-    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+    if (!isset($_POST['csrf_token']) || !isset($_SESSION['csrf_token'])) {
         return false;
     }
-
+    // Use hash_equals to prevent timing attacks
+    if (!hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        return false;
+    }
     return true;
 }
+
+sendSecurityHeaders();
 
 if (!$debug && !isValidRequest()) {
     header('Content-Type: application/json');

--- a/resources/php/includes/security_headers.php
+++ b/resources/php/includes/security_headers.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Send recommended security headers for HTML page responses.
+ * Include this file at the very top of every public-facing PHP page,
+ * before any output is sent to the client.
+ */
+
+header('X-Content-Type-Options: nosniff');
+header('X-Frame-Options: DENY');
+header('Referrer-Policy: strict-origin-when-cross-origin');
+// Allow only same-origin scripts; adjust if you use a CDN
+header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https:;");

--- a/search-user.php
+++ b/search-user.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once "resources/php/includes/security_headers.php";
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/user.php
+++ b/user.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once "resources/php/includes/security_headers.php";
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION

### Pull Request: Fix Security Vulnerabilities

---

#### Summary

This PR addresses several security vulnerabilities identified through a full codebase audit. Changes are scoped to the `security/fix-vulnerabilities` branch and cover information disclosure, header injection risks, CSRF validation weaknesses, and missing output sanitization.

---

#### Motivation

A security review revealed the following issues:

- Internal database error messages were being returned directly to the client, potentially exposing DB host, port, credentials, and schema details.
- The CSRF token comparison used `===` (strict equality), which is vulnerable to timing attacks.
- `HTTP_REFERER` was used as part of request validation, despite being trivially spoofable by any client.
- No security-related HTTP response headers were set on any page or API endpoint.
- User-supplied GET parameters in `comparison.php` were embedded into a `<script>` block without explicit sanitization.

---

#### Changes

**`resources/php/includes/db_connect.php`**
- Replaced raw `$e->getMessage()` output with a generic client-facing error message.
- Detailed exception information is now written to the server error log via `error_log()` only.

**`resources/php/includes/secure.php`**
- Removed the `HTTP_REFERER`-based host check entirely.
- Replaced `===` CSRF token comparison with `hash_equals()` to prevent timing-based attacks.
- Added `sendSecurityHeaders()` function to emit security headers on all API responses.

**`resources/php/includes/security_headers.php`** *(new file)*
- Centralized security header definitions for HTML page responses.
- Headers included:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Content-Security-Policy` with allowlisted CDN sources

**`index.php`, `user.php`, `search-user.php`, `comparison.php`**
- Added `require_once "resources/php/includes/security_headers.php"` at the top of each public-facing page.

**`comparison.php`**
- Sanitized `$_GET["player_1"]` and `$_GET["player_2"]` with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` before embedding into the JavaScript context.

---

#### Security Issues Addressed

| Severity | Issue | Status |
|----------|-------|--------|
| 🔴 High | DB error details exposed to client | ✅ Fixed |
| 🟠 Medium | `HTTP_REFERER` used for request validation | ✅ Fixed |
| 🟠 Medium | CSRF token compared with `===` (timing attack) | ✅ Fixed |
| 🟡 Low | No security HTTP headers on any response | ✅ Fixed |
| 🟡 Low | Unsanitized GET params embedded in JS block | ✅ Fixed |

---

#### Testing

- Verified that DB connection errors no longer leak internal details to the client.
- Confirmed that all public pages now return the expected security headers.
- Confirmed that `comparison.php` correctly sanitizes URL parameters before script output.

---

#### Notes

- `config/config.php` still contains hardcoded DB credentials. It is recommended to migrate these to environment variables (e.g., via `.env` + `vlucas/phpdotenv`) and add `config.php` to `.gitignore` in a follow-up PR.
- The `Content-Security-Policy` header currently allows `'unsafe-inline'` for scripts and styles. Migrating to nonce-based CSP would further harden the policy and is recommended as a future improvement.
