### PR TITLE
Add icons for crossbows, tridents, and maces skills

### DIFF
--- a/resources/js/user.js
+++ b/resources/js/user.js
@@ -542,6 +542,18 @@ function setBestAbilities(player){
                 icon.classList.add('hidden')
                 icon_mdi.classList.add('mdi-axe')
                 break;
+            case 'crossbows':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-bow-arrow')
+                break;
+            case 'tridents':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-spear')
+                break;
+            case 'maces':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-mace')
+                break;
             case 'acrobatics':
                 icon.classList.add('fa-running')
                 icon_mdi.classList.add('hidden')
@@ -643,6 +655,18 @@ function setAllAbilities(player){
             case 'axes':
                 icon.classList.add('hidden')
                 icon_mdi.classList.add('mdi-axe')
+                break;
+            case 'crossbows':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-bow-arrow')
+                break;
+            case 'tridents':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-spear')
+                break;
+            case 'maces':
+                icon.classList.add('hidden')
+                icon_mdi.classList.add('mdi-mace')
                 break;
             case 'acrobatics':
                 icon.classList.add('fa-running')


### PR DESCRIPTION
### Pull Request: Add icons for crossbows, tridents, and maces skills

#### Description

This PR adds missing skill icons for `crossbows`, `tridents`, and `maces` in the mcMMO Dashboard.
These three skills were recently added to mcMMO but had no corresponding icons in the UI, leaving them visually blank.

---

#### What changed

- Added MDI (Material Design Icons) icon mappings for the three missing skills in `resources/js/user.js`:
  - `crossbows` → `mdi-bow-arrow`
  - `tridents` → `mdi-spear`
  - `maces` → `mdi-mace`
- Both `setBestAbilities()` and `setAllAbilities()` switch statements have been updated to keep the two views consistent.

> **Note:** `mdi-trident` was considered for `tridents` but does not exist in MDI 7.1.96 (the version currently in use). `mdi-spear` was chosen as the closest available alternative.

---

#### Why these icons

| Skill | Icon | Reason |
|-------|------|--------|
| crossbows | `mdi-bow-arrow` | Directly represents a crossbow/bow weapon |
| tridents | `mdi-spear` | Closest available icon to a trident in MDI 7.1.96 |
| maces | `mdi-mace` | Exact match for the skill |

---

#### Testing

- Verified that all three icons (`mdi-bow-arrow`, `mdi-spear`, `mdi-mace`) exist in MDI 7.1.96 via CDN.
- Confirmed icons render correctly in both the Best Abilities and All Abilities sections of the user page.

---

#### Checklist

- [x] Icons exist in the currently used MDI version (7.1.96)
- [x] Both switch statements updated consistently
- [x] Follows existing code style and icon assignment pattern
- [x] No unrelated changes included
